### PR TITLE
feat: implement proper JWT configuration with HS256

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,9 @@ services:
       - DB_URL=jdbc:postgresql://postgres:5432/ticketdb
       - DB_USERNAME=${DB_USERNAME}
       - DB_PASSWORD=${DB_PASSWORD}
+      - JWT_SECRET=${JWT_SECRET}
+      - JWT_EXPIRATION=${JWT_EXPIRATION}
+      - JWT_ISSUER=${JWT_ISSUER}
     volumes:
       - ./logs:/logs
     depends_on:

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -19,5 +19,7 @@ logging.level.org.springframework.security=DEBUG
 server.port=8081
 server.ssl.enabled=false
 
-# JWT
-jwt.secret=your_test_jwt_secret_key
+# JWT Configuration
+jwt.secret=MyTestJWTSecretKeyForTestingThatIsAtLeast256BitsLongAndMeetsSecurityRequirements
+jwt.expiration=3600000
+jwt.issuer=test-ticket-api

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,7 +9,7 @@ stripe.api.key=${STRIPE_SECRET_KEY:default_test_key}
 stripe.webhook.secret=${STRIPE_WEBHOOK_SECRET:default_test_secret}
 
 # JWT Configuration
-jwt.secret=${JWT_SECRET:default-secret-key-for-development-please-change-in-production-minimum-256-bits}
+jwt.secret=${JWT_SECRET:MySecretKeyForDevelopmentThatIsAtLeast256BitsLongAndSecureEnoughForJWTAlgorithms}
 jwt.expiration=${JWT_EXPIRATION:1800000}
 jwt.issuer=${JWT_ISSUER:ticket-api}
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,6 +8,11 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 stripe.api.key=${STRIPE_SECRET_KEY:default_test_key}
 stripe.webhook.secret=${STRIPE_WEBHOOK_SECRET:default_test_secret}
 
+# JWT Configuration
+jwt.secret=${JWT_SECRET:default-secret-key-for-development-please-change-in-production-minimum-256-bits}
+jwt.expiration=${JWT_EXPIRATION:1800000}
+jwt.issuer=${JWT_ISSUER:ticket-api}
+
 # Swagger UI Configuration
 springdoc.swagger-ui.enabled=true
 

--- a/src/test/java/com/ticketapi/util/JwtUtilTest.java
+++ b/src/test/java/com/ticketapi/util/JwtUtilTest.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @TestPropertySource(properties = {
-    "jwt.secret=test-secret-key-for-testing-at-least-256-bits-long",
+    "jwt.secret=MyTestSecretKeyThatIsAtLeast256BitsLongForJWTTestingPurposesAndMeetsSecurityRequirements",
     "jwt.expiration=3600000",
     "jwt.issuer=test-issuer"
 })

--- a/src/test/java/com/ticketapi/util/JwtUtilTest.java
+++ b/src/test/java/com/ticketapi/util/JwtUtilTest.java
@@ -1,43 +1,55 @@
 package com.ticketapi.util;
 
-import io.jsonwebtoken.Claims;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.beans.factory.annotation.Autowired;
 
-import java.time.Clock;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.util.Date;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@ExtendWith(MockitoExtension.class)
+@SpringBootTest
+@TestPropertySource(properties = {
+    "jwt.secret=test-secret-key-for-testing-at-least-256-bits-long",
+    "jwt.expiration=3600000",
+    "jwt.issuer=test-issuer"
+})
 class JwtUtilTest {
 
-    @InjectMocks
+    @Autowired
     private JwtUtil jwtUtil;
 
     @Test
-    void testGenerateTokenAndExtractUsername() {
+    void testJwtTokenGeneration() {
         String username = "testuser";
-        String token = jwtUtil.generateToken(username);
-        assertEquals(username, jwtUtil.extractUsername(token));
-    }
-
-    @Test
-    void testTokenExpiration() {
-        String username = "testuser";
-        String token = jwtUtil.generateToken(username);
+        List<String> roles = List.of("USER", "ADMIN");
+        
+        String token = jwtUtil.generateToken(username, roles);
+        
+        assertNotNull(token);
+        assertFalse(token.isEmpty());
+        
+        // Verify we can extract the username
+        String extractedUsername = jwtUtil.extractUsername(token);
+        assertEquals(username, extractedUsername);
+        
+        // Verify we can extract roles
+        List<String> extractedRoles = jwtUtil.extractRoles(token);
+        assertEquals(roles, extractedRoles);
+        
+        // Verify token validation
         assertTrue(jwtUtil.validateToken(token, username));
+        assertFalse(jwtUtil.validateToken(token, "wronguser"));
     }
 
     @Test
-    void testExtractClaim() {
+    void testJwtTokenWithDefaultRole() {
         String username = "testuser";
+        
         String token = jwtUtil.generateToken(username);
-        assertEquals(username, jwtUtil.extractClaim(token, Claims::getSubject));
+        
+        List<String> extractedRoles = jwtUtil.extractRoles(token);
+        assertEquals(List.of("USER"), extractedRoles);
     }
 }


### PR DESCRIPTION
- Add JWT configuration to application.properties (secret, expiration, issuer)
- Update JwtUtil to use configured secret instead of random key generation
- Add role-based JWT claims support (USER role by default)
- Add JWT environment variables to .env and docker-compose.yml
- Create JwtUtil test to verify token generation and validation
- Fix JWT authentication reliability across application restarts

This resolves the JWT authentication issues and provides a stable foundation for scaling.