### PR TITLE
feat: Add Stripe payment integration with event pricing

### DIFF
--- a/src/main/resources/db/changelog/db.changelog-master.sql
+++ b/src/main/resources/db/changelog/db.changelog-master.sql
@@ -52,3 +52,7 @@ CREATE TABLE orders (
                         FOREIGN KEY (event_id) REFERENCES events(id)
 );
 --rollback DROP TABLE orders;
+
+--changeset Girmay:5
+ALTER TABLE events ADD COLUMN price DECIMAL(10, 2) NOT NULL DEFAULT 0.00;
+--rollback ALTER TABLE events DROP COLUMN price;

--- a/src/test/java/com/ticketapi/dao/EventDaoImplTest.java
+++ b/src/test/java/com/ticketapi/dao/EventDaoImplTest.java
@@ -8,6 +8,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -32,6 +33,7 @@ class EventDaoImplTest {
         testEvent.setVenue("Test Venue");
         testEvent.setTotalTickets(100);
         testEvent.setAvailableTickets(100);
+        testEvent.setPrice(BigDecimal.valueOf(25.00));
     }
 
     @Test
@@ -45,6 +47,7 @@ class EventDaoImplTest {
         assertEquals("Test Venue", createdEvent.getVenue());
         assertEquals(100, createdEvent.getTotalTickets());
         assertEquals(100, createdEvent.getAvailableTickets());
+        assertEquals(BigDecimal.valueOf(25.00), createdEvent.getPrice());
     }
     
     @Test
@@ -84,6 +87,7 @@ class EventDaoImplTest {
         secondEvent.setVenue("Second Venue");
         secondEvent.setTotalTickets(50);
         secondEvent.setAvailableTickets(50);
+        secondEvent.setPrice(BigDecimal.valueOf(0.00)); // Free event
         eventDao.createEvent(secondEvent);
         
         List<Event> events = eventDao.getAllEvents();
@@ -101,6 +105,7 @@ class EventDaoImplTest {
         createdEvent.setVenue("Updated Venue");
         createdEvent.setTotalTickets(200);
         createdEvent.setAvailableTickets(150);
+        createdEvent.setPrice(BigDecimal.valueOf(35.00));
         
         assertDoesNotThrow(() -> eventDao.updateEvent(createdEvent));
         
@@ -110,6 +115,7 @@ class EventDaoImplTest {
         assertEquals("Updated Venue", updatedEvent.getVenue());
         assertEquals(200, updatedEvent.getTotalTickets());
         assertEquals(150, updatedEvent.getAvailableTickets());
+        assertEquals(BigDecimal.valueOf(35.00), updatedEvent.getPrice());
     }
     
     @Test

--- a/src/test/java/com/ticketapi/dao/OrderDaoImplTest.java
+++ b/src/test/java/com/ticketapi/dao/OrderDaoImplTest.java
@@ -50,6 +50,7 @@ class OrderDaoImplTest {
         testEvent.setVenue("Test Venue");
         testEvent.setTotalTickets(100);
         testEvent.setAvailableTickets(100);
+        testEvent.setPrice(BigDecimal.valueOf(50.00)); // Add price field
         Event savedEvent = eventDao.createEvent(testEvent);
         testEventId = savedEvent.getId();
     }

--- a/src/test/resources/test-schema.sql
+++ b/src/test/resources/test-schema.sql
@@ -18,7 +18,8 @@ CREATE TABLE IF NOT EXISTS events (
     date_time TIMESTAMP NOT NULL,
     venue VARCHAR(255) NOT NULL,
     total_tickets INT NOT NULL,
-    available_tickets INT NOT NULL
+    available_tickets INT NOT NULL,
+    price DECIMAL(10, 2) NOT NULL DEFAULT 0.00
 );
 
 CREATE TABLE IF NOT EXISTS tickets (

--- a/ticket-frontend/src/App.js
+++ b/ticket-frontend/src/App.js
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
-import { Container, Typography, Box, Button, Stack } from '@mui/material';
+import { Container, Typography, Box, Button, Stack, Paper, Grid, Card, CardContent, AppBar, Toolbar } from '@mui/material';
+import { Event as EventIcon, ConfirmationNumber, LocalActivity } from '@mui/icons-material';
 import Login from './components/Login';
 import Register from './components/Register';
 import EventsList from './components/EventsList';
@@ -20,11 +21,17 @@ const theme = createTheme({
 
 function App() {
   const [currentView, setCurrentView] = useState('home');
-  const [user, setUser] = useState(null);
+  const [user, setUser] = useState(() => {
+    // Check if user is stored in localStorage on app load
+    const savedUser = localStorage.getItem('user');
+    return savedUser ? JSON.parse(savedUser) : null;
+  });
   const [selectedEvent, setSelectedEvent] = useState(null);
 
   const handleLogin = (userData) => {
     setUser(userData);
+    // Store user data in localStorage
+    localStorage.setItem('user', JSON.stringify(userData));
     console.log('User logged in:', userData);
   };
 
@@ -42,37 +49,95 @@ function App() {
       case 'home':
         return (
           <Container maxWidth="lg" sx={{ mt: 4, mb: 4 }}>
-            <Box textAlign="center">
-              <Typography variant="h2" component="h1" gutterBottom>
-                🎫 TicketMaster MVP
+            <Box textAlign="center" mb={6}>
+              <Typography variant="h2" component="h1" gutterBottom sx={{ fontWeight: 'bold' }}>
+                🎫 Event Tickets
               </Typography>
-              <Typography variant="h5" component="h2" gutterBottom>
-                {user ? `Welcome back, ${user.username || 'User'}!` : 'Backend Ready! Building Frontend Components...'}
+              <Typography variant="h5" component="h2" gutterBottom color="text.secondary">
+                {user ? `Welcome back, ${user.username}!` : 'Your gateway to amazing events'}
               </Typography>
               <Stack direction="row" spacing={2} justifyContent="center" sx={{ mt: 4 }}>
                 {!user ? (
                   <>
-                    <Button variant="contained" onClick={() => setCurrentView('login')}>
+                    <Button 
+                      variant="contained" 
+                      size="large"
+                      onClick={() => setCurrentView('login')}
+                    >
                       Login
                     </Button>
-                    <Button variant="outlined" onClick={() => setCurrentView('register')}>
+                    <Button 
+                      variant="outlined" 
+                      size="large"
+                      onClick={() => setCurrentView('register')}
+                    >
                       Register
                     </Button>
                   </>
                 ) : (
-                  <Button variant="outlined" onClick={() => { 
-                    setUser(null); 
-                    localStorage.removeItem('token'); 
-                    localStorage.removeItem('user'); 
-                  }}>
+                  <Button 
+                    variant="outlined" 
+                    onClick={() => { 
+                      setUser(null); 
+                      localStorage.removeItem('token'); 
+                      localStorage.removeItem('user'); 
+                    }}
+                  >
                     Logout
                   </Button>
                 )}
-                <Button variant="outlined" onClick={() => setCurrentView('events')}>
-                  View Events
+                <Button 
+                  variant={user ? "contained" : "outlined"} 
+                  size="large"
+                  startIcon={<EventIcon />}
+                  onClick={() => setCurrentView('events')}
+                >
+                  Browse Events
                 </Button>
               </Stack>
             </Box>
+
+            <Grid container spacing={4}>
+              <Grid item xs={12} md={4}>
+                <Card elevation={2}>
+                  <CardContent sx={{ textAlign: 'center', py: 4 }}>
+                    <EventIcon sx={{ fontSize: 48, color: 'primary.main', mb: 2 }} />
+                    <Typography variant="h6" gutterBottom>
+                      Discover Events
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      Browse through our curated selection of concerts, conferences, and exhibitions
+                    </Typography>
+                  </CardContent>
+                </Card>
+              </Grid>
+              <Grid item xs={12} md={4}>
+                <Card elevation={2}>
+                  <CardContent sx={{ textAlign: 'center', py: 4 }}>
+                    <ConfirmationNumber sx={{ fontSize: 48, color: 'primary.main', mb: 2 }} />
+                    <Typography variant="h6" gutterBottom>
+                      Secure Booking
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      Easy and secure ticket purchasing with Stripe payment processing
+                    </Typography>
+                  </CardContent>
+                </Card>
+              </Grid>
+              <Grid item xs={12} md={4}>
+                <Card elevation={2}>
+                  <CardContent sx={{ textAlign: 'center', py: 4 }}>
+                    <LocalActivity sx={{ fontSize: 48, color: 'primary.main', mb: 2 }} />
+                    <Typography variant="h6" gutterBottom>
+                      Instant Confirmation
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      Get your tickets instantly with unique confirmation codes
+                    </Typography>
+                  </CardContent>
+                </Card>
+              </Grid>
+            </Grid>
           </Container>
         );
       case 'login':
@@ -102,6 +167,44 @@ function App() {
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
+      <AppBar position="static" elevation={1}>
+        <Toolbar>
+          <Typography 
+            variant="h6" 
+            sx={{ flexGrow: 1, cursor: 'pointer' }}
+            onClick={() => setCurrentView('home')}
+          >
+            🎫 Event Tickets
+          </Typography>
+          {user ? (
+            <>
+              <Button color="inherit" onClick={() => setCurrentView('events')}>
+                Events
+              </Button>
+              <Button 
+                color="inherit" 
+                onClick={() => { 
+                  setUser(null); 
+                  localStorage.removeItem('token'); 
+                  localStorage.removeItem('user');
+                  setCurrentView('home');
+                }}
+              >
+                Logout ({user.username})
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button color="inherit" onClick={() => setCurrentView('login')}>
+                Login
+              </Button>
+              <Button color="inherit" onClick={() => setCurrentView('register')}>
+                Register
+              </Button>
+            </>
+          )}
+        </Toolbar>
+      </AppBar>
       {renderView()}
     </ThemeProvider>
   );


### PR DESCRIPTION
Backend Changes:
- Add price field (BigDecimal) to Event model and database schema
- Update EventDao to handle price in CRUD operations
- Modify OrderService and PaymentService to accept -zsh prices for free events
- Add Liquibase migration for price column
- Update test schemas and test data

Frontend Changes:
- Integrate Stripe Elements for payment processing
- Create StripePaymentForm component for card collection
- Implement EventDetails with complete purchase flow
- Add Register component
- Improve UI with navigation bar and feature cards
- Persist user session across page refreshes

Test Fixes:
- Update test-schema.sql with price column
- Fix OrderDaoImplTest and EventDaoImplTest to include price field
- Add price assertions to event tests

Payment Flow:
- Free events (-zsh): Auto-confirm without payment form
- Paid events: Display Stripe Elements form
- Support test card: 4242 4242 4242 4242